### PR TITLE
webhid transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@ledgerhq/hw-transport-u2f": "5.36.0-deprecated",
     "@ledgerhq/hw-transport-webauthn": "5.36.0-deprecated",
     "@ledgerhq/hw-transport-webusb": "5.49.0",
+    "@ledgerhq/hw-transport-webhid": "5.51.1",
     "babel-polyfill": "6.26.0",
     "bech32": "1.1.4",
     "es6-error": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "yoroi-extension-ledger-connect",
   "version": "4.0.0",
@@ -58,7 +57,7 @@
     "es6-error": "4.1.1",
     "lodash": "4.17.20",
     "mobx": "5.15.6",
-    "mobx-react": "6.2.5",
+    "mobx-react": "6.3.1",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/const.js
+++ b/src/const.js
@@ -2,13 +2,15 @@
 import { TRANSPORT_ID } from './types/enum';
 
 export const YOROI_LEDGER_CONNECT_TARGET_NAME = 'YOROI-LEDGER-CONNECT';
-export const DEFAULT_TRANSPORT_PROTOCOL = TRANSPORT_ID.WEB_AUTHN;
 export const DEFAULT_LOCALE = 'en-US';
 export const ENV = {
   isProduction: process.env.NODE_ENV === 'production',
   isDevelopment: process.env.NODE_ENV === 'development',
   isFirefox: !!window.InstallTrigger
 };
+export const DEFAULT_TRANSPORT_PROTOCOL = ENV.isFirefox
+  ? TRANSPORT_ID.WEB_AUTHN
+  : TRANSPORT_ID.WEB_HID;
 export const DEVICE_LOCK_CHECK_TIMEOUT_MS = 500; // In milli-seconds
 export const TRANSPORT_EXCHANGE_TIMEOUT_MS = 120000; // In milli-seconds
 export const SUPPORTED_VERSION = `>=2.1.0`; // supported version of the Cardano app

--- a/src/types/enum.js
+++ b/src/types/enum.js
@@ -32,6 +32,7 @@ export type DeviceCodeType = $Values<typeof DEVICE_CODE>;
 export const TRANSPORT_ID = Object.freeze({
   WEB_AUTHN: 'webauthn',
   U2F: 'u2f',
-  WEB_USB: 'webusb'
+  WEB_USB: 'webusb',
+  WEB_HID: 'webhid',
 });
 export type TransportIdType = $Values<typeof TRANSPORT_ID>;

--- a/src/utils/cmn.js
+++ b/src/utils/cmn.js
@@ -104,6 +104,9 @@ export const makeTransport = async (transportId: TransportIdType): any => {
     case TRANSPORT_ID.WEB_USB:
       transportFactory = require('@ledgerhq/hw-transport-webusb').default;
       break;
+    case TRANSPORT_ID.WEB_HID:
+      transportFactory = require('@ledgerhq/hw-transport-webhid').default;
+      break;
     default:
       throw new Error('Transport protocol not supported');
   }


### PR DESCRIPTION
For Firefox, default transport remains WebAuthn. Otherwise, use WebHID.

Tested using the built-in manual tests.

Side notes:
1. I wasn't able to run `yarn install` successfully (even on current develop branch HEAD) but `npm install` works. So `yarn.lock` is not properly updated.
2. Have to bump `mobx-react` version otherwise the app crashes (related to the previous issue).