### PR TITLE
show Bech32 pool ID when signing delegation txs using Ledger Caradano app ver >= 2.4.1

### DIFF
--- a/src/components/connect/ConnectBlock.js
+++ b/src/components/connect/ConnectBlock.js
@@ -41,7 +41,8 @@ type Props = {|
   verifyAddressInfo: ShowAddressRequestWrapper,
   deriveAddressInfo: DeriveAddressRequest,
   wasDeviceLocked: boolean,
-  response: MessageType | void
+  response: MessageType | void,
+  deviceVersion: ?string,
 |};
 
 @observer
@@ -63,6 +64,7 @@ export default class ConnectBlock extends React.Component<Props> {
       deriveAddressInfo,
       wasDeviceLocked,
       response,
+      deviceVersion,
     } = this.props;
 
     let content;
@@ -106,6 +108,7 @@ export default class ConnectBlock extends React.Component<Props> {
             verifyAddressInfo={verifyAddressInfo}
             deriveAddressInfo={deriveAddressInfo}
             wasDeviceLocked={wasDeviceLocked}
+            deviceVersion={deviceVersion}
           />
         );
     }

--- a/src/components/connect/operation/OperationBlock.js
+++ b/src/components/connect/operation/OperationBlock.js
@@ -42,6 +42,7 @@ type Props = {|
   deriveAddressInfo: DeriveAddressRequest,
   wasDeviceLocked: boolean,
   showPerformActionText?: boolean,
+  deviceVersion: ?string,
 |};
 
 @observer
@@ -62,6 +63,7 @@ export default class OperationBlock extends React.Component<Props> {
       deriveAddressInfo,
       wasDeviceLocked,
       showPerformActionText,
+      deviceVersion,
     } = this.props;
 
     let content;
@@ -104,6 +106,7 @@ export default class OperationBlock extends React.Component<Props> {
                 deviceCode={deviceCode}
                 signTxInfo={signTxInfo}
                 wasDeviceLocked={wasDeviceLocked}
+                deviceVersion={deviceVersion}
               />
             );
             break;

--- a/src/containers/ConnectPage.js
+++ b/src/containers/ConnectPage.js
@@ -31,6 +31,7 @@ export default class ConnectPage extends React.Component<Props> {
       setTransport,
       setDeviceCode,
       response,
+      deviceVersion,
     } = connectStore;
 
     const {
@@ -61,6 +62,7 @@ export default class ConnectPage extends React.Component<Props> {
           deriveAddressInfo={deriveAddressInfo}
           wasDeviceLocked={wasDeviceLocked}
           response={response}
+          deviceVersion={deviceVersion}
         />
       </Layout>
     );

--- a/src/stores/ConnectStore.js
+++ b/src/stores/ConnectStore.js
@@ -56,6 +56,7 @@ export default class ConnectStore {
   @observable deriveAddressInfo: DeriveAddressRequest;
   @observable deviceCode: DeviceCodeType
   @observable wasDeviceLocked: boolean;
+  @observable deviceVersion: string;
   @observable response: void | MessageType;
   @observable expectedSerial: ?string;
   @observable extension: ?string;
@@ -155,7 +156,9 @@ export default class ConnectStore {
     if (!semverSatisfies(semverResp, SUPPORTED_VERSION)) {
       throw new Error(`Incorrect Cardano app version. Supports version ${SUPPORTED_VERSION} but you have version ${semverResp}`);
     }
-
+    runInAction(() => {
+      this.deviceVersion = semverResp;
+    });
     this.setProgressState(PROGRESS_STATE.DEVICE_FOUND);
 
     return {


### PR DESCRIPTION
Since v2.4.1 the Ledger Cardano app shows Bech32 pool ID instead of the raw pool ID in hex (https://github.com/vacuumlabs/ledger-app-cardano-shelley/pull/84/files). On the steps page, we are showing the pool ID in hex. The inconsistency confuses users (https://github.com/Emurgo/yoroi-frontend/issues/2211).

This PR passes the device version down to the point where the pool ID is shown and depending on whether it's >= 2.4.1, convert it to Bech32.

